### PR TITLE
ignore 404 on Network.remove()

### DIFF
--- a/golem_core/low/network.py
+++ b/golem_core/low/network.py
@@ -65,7 +65,7 @@ class Network(Resource[RequestorApi, models.Network, _NULL, _NULL, _NULL]):
         created_data = await api.create_network(in_data)
         return cls(golem_node, created_data.id, created_data)
 
-    @api_call_wrapper()
+    @api_call_wrapper(ignore=[404])
     async def remove(self) -> None:
         """Remove the network."""
         await self.api.remove_network(self.id)


### PR DESCRIPTION
This makes a difference e.g. in:
```
import asyncio

from golem_core import GolemNode

async def main():
    async with GolemNode() as golem:
        network = await golem.create_network("192.168.0.1/24")
        await network.remove()


asyncio.run(main())
```
because network is removed twice, second time in `GolemNode.__aexit__`.

After the change behavior will be consistent with e.g. `Demand.unsubscribe()` and `Allocation.release()`.