### PR TITLE
TraceId in logs

### DIFF
--- a/examples/managers/blender/blender.py
+++ b/examples/managers/blender/blender.py
@@ -36,12 +36,15 @@ async def run_on_golem(
     init_func,
     threads=6,
     budget=1.0,
-    negotiators=[
-        AddChosenPaymentPlatform(),
-    ],
+    negotiators=None,
     scorers=None,
     task_plugins=None,
 ):
+    if negotiators is None:
+        negotiators = [
+            AddChosenPaymentPlatform(),
+        ]
+
     golem = GolemNode()
 
     payment_manager = PayAllPaymentManager(golem, budget=budget)

--- a/golem/event_bus/in_memory/event_bus.py
+++ b/golem/event_bus/in_memory/event_bus.py
@@ -6,7 +6,7 @@ from typing import Awaitable, Callable, DefaultDict, List, Optional, Tuple, Type
 
 from golem.event_bus.base import Event, EventBus, EventBusError, TEvent
 from golem.utils.asyncio import create_task_with_logging
-from golem.utils.logging import trace_span
+from golem.utils.logging import get_trace_id_name, trace_span
 
 logger = logging.getLogger(__name__)
 
@@ -35,7 +35,8 @@ class InMemoryEventBus(EventBus[_CallbackHandler]):
             raise EventBusError(message)
 
         self._process_event_queue_loop_task = create_task_with_logging(
-            self._process_event_queue_loop()
+            self._process_event_queue_loop(),
+            trace_id=get_trace_id_name(self, "process-event-queue-loop"),
         )
 
     @trace_span()

--- a/golem/managers/activity/single_use.py
+++ b/golem/managers/activity/single_use.py
@@ -26,7 +26,6 @@ class SingleUseActivityManager(ActivityPrepareReleaseMixin, ActivityManager):
             agreement = await self._get_agreement()
             try:
                 activity = await self._prepare_activity(agreement)
-                logger.info(f"Activity `{activity}` created")
                 try:
                     yield activity
                 finally:

--- a/golem/managers/agreement/default.py
+++ b/golem/managers/agreement/default.py
@@ -22,7 +22,7 @@ class DefaultAgreementManager(AgreementManager):
 
         super().__init__(*args, **kwargs)
 
-    @trace_span(show_arguments=True)
+    @trace_span("Getting agreement", show_results=True, log_level=logging.INFO)
     async def get_agreement(self) -> Agreement:
         while True:
             proposal = await self._get_draft_proposal()
@@ -33,8 +33,6 @@ class DefaultAgreementManager(AgreementManager):
             except Exception as e:
                 logger.debug(f"Creating agreement failed with `{e}`. Retrying...")
             else:
-                logger.info(f"Agreement `{agreement}` created")
-
                 # TODO: Support removing callback on resource close
                 await self._event_bus.on_once(
                     ActivityClosed,

--- a/golem/managers/demand/refreshing.py
+++ b/golem/managers/demand/refreshing.py
@@ -49,7 +49,7 @@ class RefreshingDemandManager(BackgroundLoopMixin, DemandManager):
     async def stop(self) -> None:
         return await super().stop()
 
-    @trace_span("Getting initial proposal", show_results=True, log_level=logging.INFO)
+    @trace_span("Getting initial proposal", show_results=True)
     async def get_initial_proposal(self) -> Proposal:
         return await self._get_initial_proposal()
 

--- a/golem/managers/demand/refreshing.py
+++ b/golem/managers/demand/refreshing.py
@@ -10,7 +10,7 @@ from golem.payload import Payload, PayloadSyntaxParser
 from golem.resources import Allocation, Demand, Proposal
 from golem.resources.demand.demand_builder import DemandBuilder
 from golem.utils.asyncio import create_task_with_logging
-from golem.utils.logging import trace_span
+from golem.utils.logging import get_trace_id_name, trace_span
 
 logger = logging.getLogger(__name__)
 
@@ -28,10 +28,12 @@ class RefreshingDemandManager(BackgroundLoopMixin, DemandManager):
         self._golem = golem
         self._get_allocation = get_allocation
         self._payload = payload
+
         if demand_offer_parser is None:
             from golem.payload.parsers.textx import TextXPayloadSyntaxParser
 
             demand_offer_parser = TextXPayloadSyntaxParser()
+
         self._demand_offer_parser = demand_offer_parser
 
         self._initial_proposals: asyncio.Queue[Proposal] = asyncio.Queue()
@@ -39,7 +41,15 @@ class RefreshingDemandManager(BackgroundLoopMixin, DemandManager):
         self._demands: List[Tuple[Demand, asyncio.Task]] = []
         super().__init__(*args, **kwargs)
 
-    @trace_span(show_results=True)
+    @trace_span("Starting RefreshingDemandManager", log_level=logging.INFO)
+    async def start(self) -> None:
+        return await super().start()
+
+    @trace_span("Stopping RefreshingDemandManager", log_level=logging.INFO)
+    async def stop(self) -> None:
+        return await super().stop()
+
+    @trace_span("Getting initial proposal", show_results=True, log_level=logging.INFO)
     async def get_initial_proposal(self) -> Proposal:
         return await self._get_initial_proposal()
 
@@ -77,7 +87,13 @@ class RefreshingDemandManager(BackgroundLoopMixin, DemandManager):
         demand.start_collecting_events()
         await demand.get_data()
         self._demands.append(
-            (demand, create_task_with_logging(self._consume_initial_proposals(demand)))
+            (
+                demand,
+                create_task_with_logging(
+                    self._consume_initial_proposals(demand),
+                    trace_id=get_trace_id_name(self, f"demand-{demand.id}-proposal-consumer-loop"),
+                ),
+            )
         )
 
     @trace_span()
@@ -87,7 +103,7 @@ class RefreshingDemandManager(BackgroundLoopMixin, DemandManager):
                 logger.debug(f"New initial proposal {initial}")
                 self._initial_proposals.put_nowait(initial)
         except asyncio.CancelledError:
-            ...
+            pass
 
     @trace_span()
     def _stop_consuming_initial_proposals(self) -> List[bool]:

--- a/golem/managers/mixins.py
+++ b/golem/managers/mixins.py
@@ -4,7 +4,7 @@ from typing import Generic, List, Optional, Sequence
 
 from golem.managers.base import ManagerException, TPlugin
 from golem.utils.asyncio import create_task_with_logging
-from golem.utils.logging import trace_span
+from golem.utils.logging import get_trace_id_name, trace_span
 
 logger = logging.getLogger(__name__)
 
@@ -15,14 +15,15 @@ class BackgroundLoopMixin:
 
         super().__init__(*args, **kwargs)
 
-    @trace_span()
     async def start(self) -> None:
         if self.is_started():
             raise ManagerException("Already started!")
 
-        self._background_loop_task = create_task_with_logging(self._background_loop())
+        self._background_loop_task = create_task_with_logging(
+            self._background_loop(),
+            trace_id=get_trace_id_name(self, "background-loop"),
+        )
 
-    @trace_span()
     async def stop(self) -> None:
         if not self.is_started():
             raise ManagerException("Already stopped!")

--- a/golem/managers/proposal/default.py
+++ b/golem/managers/proposal/default.py
@@ -1,9 +1,11 @@
+import logging
 from typing import Awaitable, Callable, List, Optional, Sequence
 
 from golem.managers.base import ProposalManager, ProposalManagerPlugin
 from golem.managers.proposal.plugins.negotiating.negotiating_plugin import NegotiatingPlugin
 from golem.node.node import GolemNode
 from golem.resources import Proposal
+from golem.utils.logging import trace_span
 
 
 class DefaultProposalManager(ProposalManager):
@@ -20,15 +22,18 @@ class DefaultProposalManager(ProposalManager):
             list(plugins) if plugins is not None else [NegotiatingPlugin()]
         )
 
+    @trace_span("Getting draft proposal", show_results=True, log_level=logging.INFO)
     async def get_draft_proposal(self) -> Proposal:
         return await self._get_proposal_with_plugins()
 
+    @trace_span("Starting DefaultProposalManager", log_level=logging.INFO)
     async def start(self) -> None:
         for p in self._plugins:
             p.set_proposal_callback(self._get_proposal_with_plugins)
             self._get_proposal_with_plugins = p.get_proposal
             await p.start()
 
+    @trace_span("Stopping DefaultProposalManager", log_level=logging.INFO)
     async def stop(self) -> None:
         for p in reversed(self._plugins):
             await p.stop()

--- a/golem/managers/proposal/default.py
+++ b/golem/managers/proposal/default.py
@@ -22,7 +22,7 @@ class DefaultProposalManager(ProposalManager):
             list(plugins) if plugins is not None else [NegotiatingPlugin()]
         )
 
-    @trace_span("Getting draft proposal", show_results=True, log_level=logging.INFO)
+    @trace_span("Getting draft proposal", show_results=True)
     async def get_draft_proposal(self) -> Proposal:
         return await self._get_proposal_with_plugins()
 

--- a/golem/managers/proposal/plugins/buffer.py
+++ b/golem/managers/proposal/plugins/buffer.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 from golem.managers import ProposalManagerPlugin
 from golem.resources import Proposal
 from golem.utils.asyncio import create_task_with_logging
-from golem.utils.logging import trace_span
+from golem.utils.logging import get_trace_id_name, trace_span
 
 logger = logging.getLogger(__name__)
 
@@ -46,8 +46,12 @@ class Buffer(ProposalManagerPlugin):
         if self.is_started():
             raise RuntimeError("Already started!")
 
-        for _ in range(self._concurrency_size):
-            self._worker_tasks.append(create_task_with_logging(self._worker_loop()))
+        for i in range(self._concurrency_size):
+            self._worker_tasks.append(
+                create_task_with_logging(
+                    self._worker_loop(), trace_id=get_trace_id_name(self, f"worker-{i}")
+                )
+            )
 
         if self._fill_at_start:
             self._handle_item_requests()

--- a/golem/managers/proposal/plugins/negotiating/negotiating_plugin.py
+++ b/golem/managers/proposal/plugins/negotiating/negotiating_plugin.py
@@ -90,7 +90,7 @@ class NegotiatingPlugin(ProposalManagerPlugin):
         except (ApiException, asyncio.TimeoutError) as e:
             raise RuntimeError(f"Failed to send proposal response! {e}") from e
 
-    @trace_span
+    @trace_span()
     async def _reject_proposal(self, offer_proposal: Proposal) -> None:
         await offer_proposal.reject()
 

--- a/golem/managers/proposal/plugins/negotiating/negotiating_plugin.py
+++ b/golem/managers/proposal/plugins/negotiating/negotiating_plugin.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 from copy import deepcopy
 from datetime import datetime
 from typing import List, Optional, Sequence, cast
@@ -38,10 +39,12 @@ class NegotiatingPlugin(ProposalManagerPlugin):
 
             demand_data = await self._get_demand_data_from_proposal(proposal)
 
-            offer_proposal = await self._negotiate_proposal(demand_data, proposal)
-
-            if offer_proposal is not None:
-                return offer_proposal
+            try:
+                return await self._negotiate_proposal(demand_data, proposal)
+            except Exception:
+                logging.debug(
+                    f"Negotiation based on proposal `{proposal}` failed, retrying with new one..."
+                )
 
     @trace_span(show_arguments=True, show_results=True)
     async def _negotiate_proposal(
@@ -52,11 +55,11 @@ class NegotiatingPlugin(ProposalManagerPlugin):
 
             try:
                 await self._run_negotiators(demand_data_after_negotiators, offer_proposal)
-            except RejectProposal as e:
+            except RejectProposal:
                 if not offer_proposal.initial:
-                    await offer_proposal.reject(str(e))
+                    await self._reject_proposal(offer_proposal)
 
-                return None
+                raise
 
             if not offer_proposal.initial and demand_data_after_negotiators == demand_data:
                 return offer_proposal
@@ -64,12 +67,7 @@ class NegotiatingPlugin(ProposalManagerPlugin):
             demand_data = demand_data_after_negotiators
 
             demand_proposal = await self._send_demand_proposal(offer_proposal, demand_data)
-            if demand_proposal is None:
-                return None
-
             new_offer_proposal = await self._wait_for_proposal_response(demand_proposal)
-            if new_offer_proposal is None:
-                return None
 
             offer_proposal = new_offer_proposal
 
@@ -77,8 +75,8 @@ class NegotiatingPlugin(ProposalManagerPlugin):
     async def _wait_for_proposal_response(self, demand_proposal: Proposal) -> Optional[Proposal]:
         try:
             return await demand_proposal.responses().__anext__()
-        except StopAsyncIteration:
-            return None
+        except StopAsyncIteration as e:
+            raise RuntimeError("Failed to receive proposal response!") from e
 
     @trace_span()
     async def _send_demand_proposal(
@@ -89,8 +87,12 @@ class NegotiatingPlugin(ProposalManagerPlugin):
                 demand_data.properties,
                 demand_data.constraints,
             )
-        except (ApiException, asyncio.TimeoutError):
-            return None
+        except (ApiException, asyncio.TimeoutError) as e:
+            raise RuntimeError(f"Failed to send proposal response! {e}") from e
+
+    @trace_span
+    async def _reject_proposal(self, offer_proposal: Proposal) -> None:
+        await offer_proposal.reject()
 
     async def _get_demand_data_from_proposal(self, proposal: Proposal) -> DemandData:
         # FIXME: Unnecessary serialisation from DemandBuilder to Demand,

--- a/golem/managers/proposal/plugins/negotiating/negotiating_plugin.py
+++ b/golem/managers/proposal/plugins/negotiating/negotiating_plugin.py
@@ -49,7 +49,7 @@ class NegotiatingPlugin(ProposalManagerPlugin):
     @trace_span(show_arguments=True, show_results=True)
     async def _negotiate_proposal(
         self, demand_data: DemandData, offer_proposal: Proposal
-    ) -> Optional[Proposal]:
+    ) -> Proposal:
         while True:
             demand_data_after_negotiators = deepcopy(demand_data)
 
@@ -72,7 +72,7 @@ class NegotiatingPlugin(ProposalManagerPlugin):
             offer_proposal = new_offer_proposal
 
     @trace_span()
-    async def _wait_for_proposal_response(self, demand_proposal: Proposal) -> Optional[Proposal]:
+    async def _wait_for_proposal_response(self, demand_proposal: Proposal) -> Proposal:
         try:
             return await demand_proposal.responses().__anext__()
         except StopAsyncIteration as e:
@@ -81,7 +81,7 @@ class NegotiatingPlugin(ProposalManagerPlugin):
     @trace_span()
     async def _send_demand_proposal(
         self, offer_proposal: Proposal, demand_data: DemandData
-    ) -> Optional[Proposal]:
+    ) -> Proposal:
         try:
             return await offer_proposal.respond(
                 demand_data.properties,

--- a/golem/managers/proposal/plugins/scoring/scoring_buffer.py
+++ b/golem/managers/proposal/plugins/scoring/scoring_buffer.py
@@ -7,7 +7,7 @@ from golem.managers.proposal.plugins.buffer import Buffer
 from golem.managers.proposal.plugins.scoring.mixins import ProposalScoringMixin
 from golem.resources import Proposal
 from golem.utils.asyncio import create_task_with_logging
-from golem.utils.logging import trace_span
+from golem.utils.logging import get_trace_id_name, trace_span
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +32,9 @@ class ScoringBuffer(ProposalScoringMixin, Buffer):
     async def start(self) -> None:
         await super().start()
 
-        self._background_loop_task = create_task_with_logging(self._background_loop())
+        self._background_loop_task = create_task_with_logging(
+            self._background_loop(), trace_id=get_trace_id_name(self, "background-loop")
+        )
 
     @trace_span()
     async def stop(self) -> None:

--- a/golem/managers/work/concurrent.py
+++ b/golem/managers/work/concurrent.py
@@ -6,7 +6,7 @@ from golem.managers.base import DoWorkCallable, Work, WorkManager, WorkResult
 from golem.managers.work.mixins import WorkManagerPluginsMixin
 from golem.node import GolemNode
 from golem.utils.asyncio import create_task_with_logging
-from golem.utils.logging import trace_span
+from golem.utils.logging import get_trace_id_name, trace_span
 
 logger = logging.getLogger(__name__)
 
@@ -21,15 +21,16 @@ class ConcurrentWorkManager(WorkManagerPluginsMixin, WorkManager):
 
         super().__init__(*args, **kwargs)
 
-    @trace_span(show_arguments=True, show_results=True)
+    @trace_span("Doing work", show_arguments=True, show_results=True, log_level=logging.INFO)
     async def do_work(self, work: Work) -> WorkResult:
-        result = await self._do_work_with_plugins(self._do_work, work)
-        logger.info(f"Work `{work}` completed")
-        return result
+        return await self._do_work_with_plugins(self._do_work, work)
 
-    @trace_span(show_arguments=True, show_results=True)
+    @trace_span("Doing work list", show_arguments=True, show_results=True, log_level=logging.INFO)
     async def do_work_list(self, work_list: List[Work]) -> List[WorkResult]:
-        workers = [create_task_with_logging(self.worker()) for _ in range(self._size)]
+        workers = [
+            create_task_with_logging(self.worker(), trace_id=get_trace_id_name(self, f"worker-{i}"))
+            for i in range(self._size)
+        ]
         for work in work_list:
             self._queue.put_nowait(work)
         await self._queue.join()
@@ -39,7 +40,12 @@ class ConcurrentWorkManager(WorkManagerPluginsMixin, WorkManager):
 
     async def worker(self):
         while True:
-            work = await self._queue.get()
+            work = await self._get_work_from_queue()
+
             result = await self.do_work(work)
             self._queue.task_done()
             self._results.append(result)
+
+    @trace_span(show_results=True)
+    async def _get_work_from_queue(self) -> Work:
+        return await self._queue.get()

--- a/golem/managers/work/sequential.py
+++ b/golem/managers/work/sequential.py
@@ -15,15 +15,11 @@ class SequentialWorkManager(WorkManagerPluginsMixin, WorkManager):
 
         super().__init__(*args, **kwargs)
 
-    @trace_span(show_arguments=True, show_results=True)
+    @trace_span("Doing work", show_arguments=True, show_results=True, log_level=logging.INFO)
     async def do_work(self, work: Work) -> WorkResult:
-        result = await self._do_work_with_plugins(self._do_work, work)
+        return await self._do_work_with_plugins(self._do_work, work)
 
-        logger.info(f"Work `{work}` completed")
-
-        return result
-
-    @trace_span(show_arguments=True, show_results=True)
+    @trace_span("Doing work list", show_arguments=True, show_results=True, log_level=logging.INFO)
     async def do_work_list(self, work_list: List[Work]) -> List[WorkResult]:
         results = []
 

--- a/golem/utils/asyncio.py
+++ b/golem/utils/asyncio.py
@@ -1,10 +1,21 @@
 import asyncio
+import contextvars
 import logging
+
+from golem.utils.logging import trace_id_var
 
 logger = logging.getLogger(__name__)
 
 
-def create_task_with_logging(coro) -> asyncio.Task:
+def create_task_with_logging(coro, *, trace_id=None) -> asyncio.Task:
+    context = contextvars.copy_context()
+    return context.run(_create_task_with_logging, coro, trace_id=trace_id)
+
+
+def _create_task_with_logging(coro, *, trace_id=None) -> asyncio.Task:
+    if trace_id is not None:
+        trace_id_var.set(trace_id)
+
     task = asyncio.create_task(coro)
     task.add_done_callback(_handle_task_logging)
     return task

--- a/golem/utils/logging.py
+++ b/golem/utils/logging.py
@@ -19,7 +19,8 @@ DEFAULT_LOGGING = {
     },
     "formatters": {
         "default": {
-            "format": "[%(asctime)s] [%(levelname)-7s] [%(traceid)s] [%(name)s:%(lineno)d] %(message)s",
+            "format": "[%(asctime)s] [%(levelname)-7s] [%(traceid)s] "
+            "[%(name)s:%(lineno)d] %(message)s",
         },
     },
     "handlers": {

--- a/golem/utils/logging.py
+++ b/golem/utils/logging.py
@@ -19,7 +19,7 @@ DEFAULT_LOGGING = {
     },
     "formatters": {
         "default": {
-            "format": "[%(asctime)s] [%(levelname)-7s] [%(name)s:%(lineno)d] [%(traceid)s] %(message)s",
+            "format": "[%(asctime)s] [%(levelname)-7s] [%(traceid)s] [%(name)s:%(lineno)d] %(message)s",
         },
     },
     "handlers": {

--- a/tests/unit/utils/test_logging.py
+++ b/tests/unit/utils/test_logging.py
@@ -161,8 +161,8 @@ def test_trace_span_on_async_function_with_log_level(caplog):
     assert asyncio.run(foobar(value)) == value
 
     assert caplog.record_tuples == [
-        ("tests.unit.utils.test_logging", log_level, f"Calling foobar..."),
-        ("tests.unit.utils.test_logging", log_level, f"Calling foobar done"),
+        ("tests.unit.utils.test_logging", log_level, "Calling foobar..."),
+        ("tests.unit.utils.test_logging", log_level, "Calling foobar done"),
     ]
 
 


### PR DESCRIPTION
What I've done:
- Implemented `trace_id_var` ContextVar as a special variable that can help with tracing logs. Managers background loops have different value, without explicit setup `root` value is used.
- Added `log_level` to `trace_span` to help with log visibility 
- Reorganized a little `NegotiatingPlugin` to have more readable logs

Notable remarks:
- First I've tried using async task name, but it turns out that we have some limited possibilities to rule over their names, as some built-in functions runs new tasks in the background and we can't truly base on them.
- We don't get contents of proposal refusal from providers side. This should be fixed soon