### PR TITLE
Refactor work manager interface

### DIFF
--- a/examples/managers/basic_composition.py
+++ b/examples/managers/basic_composition.py
@@ -61,7 +61,7 @@ async def main():
     )
     agreement_manager = DefaultAgreementManager(golem, proposal_manager.get_draft_proposal)
     activity_manager = SingleUseActivityManager(golem, agreement_manager.get_agreement)
-    work_manager = SequentialWorkManager(golem, activity_manager.do_work)
+    work_manager = SequentialWorkManager(golem, activity_manager.get_activity)
 
     async with golem:
         async with payment_manager, demand_manager, proposal_manager, agreement_manager:

--- a/examples/managers/blender/blender.py
+++ b/examples/managers/blender/blender.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from typing import List
 
 from golem.managers import (
-    ActivityPoolManager,
     AddChosenPaymentPlatform,
     ConcurrentWorkManager,
     DefaultAgreementManager,
@@ -15,6 +14,7 @@ from golem.managers import (
     MapScore,
     NegotiatingPlugin,
     PayAllPaymentManager,
+    PoolActivityManager,
     RefreshingDemandManager,
     ScoringBuffer,
     WorkContext,
@@ -65,11 +65,11 @@ async def run_on_golem(
         golem,
         proposal_manager.get_draft_proposal,
     )
-    activity_manager = ActivityPoolManager(
+    activity_manager = PoolActivityManager(
         golem, agreement_manager.get_agreement, pool_size=threads, on_activity_start=init_func
     )
     work_manager = ConcurrentWorkManager(
-        golem, activity_manager.do_work, size=threads, plugins=task_plugins
+        golem, activity_manager.get_activity, size=threads, plugins=task_plugins
     )
 
     async with golem, payment_manager, demand_manager, proposal_manager, agreement_manager, activity_manager:  # noqa: E501 line too long

--- a/examples/managers/flexible_negotiation.py
+++ b/examples/managers/flexible_negotiation.py
@@ -2,7 +2,6 @@ import asyncio
 import logging.config
 
 from golem.managers import (
-    ActivityPoolManager,
     AddChosenPaymentPlatform,
     BlacklistProviderIdPlugin,
     Buffer,
@@ -10,6 +9,7 @@ from golem.managers import (
     DefaultProposalManager,
     NegotiatingPlugin,
     PayAllPaymentManager,
+    PoolActivityManager,
     RefreshingDemandManager,
     SequentialWorkManager,
     WorkContext,
@@ -64,8 +64,8 @@ async def main():
     )
 
     agreement_manager = DefaultAgreementManager(golem, proposal_manager.get_draft_proposal)
-    activity_manager = ActivityPoolManager(golem, agreement_manager.get_agreement, pool_size=3)
-    work_manager = SequentialWorkManager(golem, activity_manager.do_work)
+    activity_manager = PoolActivityManager(golem, agreement_manager.get_agreement, pool_size=3)
+    work_manager = SequentialWorkManager(golem, activity_manager.get_activity)
 
     async with golem:
         async with payment_manager, demand_manager, proposal_manager, agreement_manager, activity_manager:  # noqa: E501 line too long

--- a/examples/managers/proposal_plugins.py
+++ b/examples/managers/proposal_plugins.py
@@ -4,7 +4,6 @@ from datetime import timedelta
 from random import randint, random
 
 from golem.managers import (
-    ActivityPoolManager,
     AddChosenPaymentPlatform,
     BlacklistProviderIdNegotiator,
     BlacklistProviderIdPlugin,
@@ -15,6 +14,7 @@ from golem.managers import (
     MapScore,
     NegotiatingPlugin,
     PayAllPaymentManager,
+    PoolActivityManager,
     PropertyValueLerpScore,
     RandomScore,
     RefreshingDemandManager,
@@ -122,10 +122,10 @@ async def main():
         golem,
         proposal_manager.get_draft_proposal,
     )
-    activity_manager = ActivityPoolManager(golem, agreement_manager.get_agreement, pool_size=3)
+    activity_manager = PoolActivityManager(golem, agreement_manager.get_agreement, pool_size=3)
     work_manager = SequentialWorkManager(
         golem,
-        activity_manager.do_work,
+        activity_manager.get_activity,
         plugins=[
             retry(tries=5),
         ],

--- a/examples/managers/ssh.py
+++ b/examples/managers/ssh.py
@@ -105,7 +105,7 @@ async def main():
         agreement_manager.get_agreement,
         on_activity_start=ssh_handler.on_activity_start,
     )
-    work_manager = SequentialWorkManager(golem, activity_manager.do_work)
+    work_manager = SequentialWorkManager(golem, activity_manager.get_activity)
     async with golem, network_manager, payment_manager, demand_manager, proposal_manager, agreement_manager:  # noqa: E501 line too long
         task = asyncio.create_task(work_manager.do_work(ssh_handler.work))
         while not ssh_handler.started:

--- a/golem/managers/__init__.py
+++ b/golem/managers/__init__.py
@@ -1,4 +1,4 @@
-from golem.managers.activity import ActivityPoolManager, SingleUseActivityManager
+from golem.managers.activity import PoolActivityManager, SingleUseActivityManager
 from golem.managers.agreement import DefaultAgreementManager
 from golem.managers.base import (
     ActivityManager,
@@ -46,7 +46,7 @@ from golem.managers.work import (
 )
 
 __all__ = (
-    "ActivityPoolManager",
+    "PoolActivityManager",
     "SingleUseActivityManager",
     "DefaultAgreementManager",
     "DoWorkCallable",

--- a/golem/managers/activity/__init__.py
+++ b/golem/managers/activity/__init__.py
@@ -1,12 +1,12 @@
 from golem.managers.activity.defaults import default_on_activity_start, default_on_activity_stop
 from golem.managers.activity.mixins import ActivityPrepareReleaseMixin
-from golem.managers.activity.pool import ActivityPoolManager
+from golem.managers.activity.pool import PoolActivityManager
 from golem.managers.activity.single_use import SingleUseActivityManager
 
 __all__ = (
     "default_on_activity_start",
     "default_on_activity_stop",
     "ActivityPrepareReleaseMixin",
-    "ActivityPoolManager",
+    "PoolActivityManager",
     "SingleUseActivityManager",
 )

--- a/golem/managers/activity/mixins.py
+++ b/golem/managers/activity/mixins.py
@@ -10,15 +10,12 @@ from golem.utils.logging import trace_span
 logger = logging.getLogger(__name__)
 
 
-class ActivityWrapperMixin:
-    def __init__(self, activity: Activity, *args, **kwargs) -> None:
+class ActivityWrapper:
+    def __init__(self, activity: Activity) -> None:
         self._activity = activity
 
-        super().__init__(*args, **kwargs)
-
     def __getattr__(self, item):
-        result = self._activity.__getattribute__(item)
-        return result
+        return getattr(self._activity, item)
 
 
 class ActivityPrepareReleaseMixin:

--- a/golem/managers/activity/mixins.py
+++ b/golem/managers/activity/mixins.py
@@ -18,8 +18,6 @@ class ActivityWrapperMixin:
 
     def __getattr__(self, item):
         result = self._activity.__getattribute__(item)
-        if callable(result):
-            return lambda *args, **kwargs: result(*args, **kwargs)
         return result
 
 

--- a/golem/managers/activity/mixins.py
+++ b/golem/managers/activity/mixins.py
@@ -10,6 +10,19 @@ from golem.utils.logging import trace_span
 logger = logging.getLogger(__name__)
 
 
+class ActivityWrapperMixin:
+    def __init__(self, activity: Activity, *args, **kwargs) -> None:
+        self._activity = activity
+
+        super().__init__(*args, **kwargs)
+
+    def __getattr__(self, item):
+        result = self._activity.__getattribute__(item)
+        if callable(result):
+            return lambda *args, **kwargs: result(*args, **kwargs)
+        return result
+
+
 class ActivityPrepareReleaseMixin:
     _event_bus: EventBus
 

--- a/golem/managers/activity/pool.py
+++ b/golem/managers/activity/pool.py
@@ -61,7 +61,7 @@ class PoolActivityManager(BackgroundLoopMixin, ActivityPrepareReleaseMixin, Acti
                 # TODO: Use events instead of sleep
                 await asyncio.sleep(0.01)
         finally:
-            logger.info(f"Releasing all {self._pool_current_size} activity from ol")
+            logger.info(f"Releasing all {self._pool_current_size} activities from the pool")
             # TODO cancel release adn prepare tasks
             await asyncio.gather(
                 *[

--- a/golem/managers/agreement/default.py
+++ b/golem/managers/agreement/default.py
@@ -25,7 +25,7 @@ class DefaultAgreementManager(AgreementManager):
 
         super().__init__(*args, **kwargs)
 
-    @trace_span()
+    @trace_span("Stopping DefaultAgreementManager", log_level=logging.INFO)
     async def stop(self) -> None:
         if self._agreements:
             await asyncio.gather(

--- a/golem/managers/agreement/default.py
+++ b/golem/managers/agreement/default.py
@@ -61,7 +61,7 @@ class DefaultAgreementManager(AgreementManager):
         try:
             self._agreements.remove(agreement)
         except ValueError:
-            logger.warning(f"{agreement} not found when removing it from tracked list")
+            logger.warning(f"Agreement `{agreement}` not found when removing it from tracked list")
         await agreement.terminate()
 
         logger.info(f"Agreement `{agreement}` closed")

--- a/golem/managers/agreement/default.py
+++ b/golem/managers/agreement/default.py
@@ -1,5 +1,6 @@
+import asyncio
 import logging
-from typing import Awaitable, Callable
+from typing import Awaitable, Callable, List
 
 from golem.managers.base import AgreementManager
 from golem.node import GolemNode
@@ -20,7 +21,18 @@ class DefaultAgreementManager(AgreementManager):
         self._get_draft_proposal = get_draft_proposal
         self._event_bus = golem.event_bus
 
+        self._agreements: List[Agreement] = []
+
         super().__init__(*args, **kwargs)
+
+    @trace_span()
+    async def stop(self) -> None:
+        if self._agreements:
+            await asyncio.gather(
+                *[agreement.terminate() for agreement in self._agreements], return_exceptions=True
+            )
+        else:
+            logger.info("All agreements are already terminated")
 
     @trace_span("Getting agreement", show_results=True, log_level=logging.INFO)
     async def get_agreement(self) -> Agreement:
@@ -39,11 +51,17 @@ class DefaultAgreementManager(AgreementManager):
                     self._terminate_agreement,
                     lambda event: event.resource.parent.id == agreement.id,
                 )
+                self._agreements.append(agreement)
                 return agreement
 
     @trace_span(show_arguments=True)
     async def _terminate_agreement(self, event: ActivityClosed) -> None:
         # TODO ensure agreement it is terminated on SIGINT
         agreement: Agreement = event.resource.parent
+        try:
+            self._agreements.remove(agreement)
+        except ValueError:
+            logger.warning(f"{agreement} not found when removing it from tracked list")
         await agreement.terminate()
+
         logger.info(f"Agreement `{agreement}` closed")

--- a/golem/managers/base.py
+++ b/golem/managers/base.py
@@ -153,7 +153,7 @@ class AgreementManager(Manager, ABC):
 
 class ActivityManager(Manager, ABC):
     @abstractmethod
-    async def do_work(self, work: Work) -> WorkResult:
+    async def get_activity(self) -> Activity:
         ...
 
 

--- a/golem/managers/work/concurrent.py
+++ b/golem/managers/work/concurrent.py
@@ -1,19 +1,27 @@
 import asyncio
 import logging
-from typing import List
+from typing import Awaitable, Callable, List
 
-from golem.managers.base import DoWorkCallable, Work, WorkManager, WorkResult
-from golem.managers.work.mixins import WorkManagerPluginsMixin
+from golem.managers.base import Work, WorkManager, WorkResult
+from golem.managers.work.mixins import WorkManagerDoWorkMixin, WorkManagerPluginsMixin
 from golem.node import GolemNode
+from golem.resources import Activity
 from golem.utils.asyncio import create_task_with_logging
 from golem.utils.logging import get_trace_id_name, trace_span
 
 logger = logging.getLogger(__name__)
 
 
-class ConcurrentWorkManager(WorkManagerPluginsMixin, WorkManager):
-    def __init__(self, golem: GolemNode, do_work: DoWorkCallable, size: int, *args, **kwargs):
-        self._do_work = do_work
+class ConcurrentWorkManager(WorkManagerPluginsMixin, WorkManagerDoWorkMixin, WorkManager):
+    def __init__(
+        self,
+        golem: GolemNode,
+        get_activity: Callable[[], Awaitable[Activity]],
+        size: int,
+        *args,
+        **kwargs,
+    ):
+        self._get_activity = get_activity
         self._size = size
 
         self._queue: asyncio.Queue[Work] = asyncio.Queue()

--- a/golem/managers/work/sequential.py
+++ b/golem/managers/work/sequential.py
@@ -1,17 +1,20 @@
 import logging
-from typing import List
+from typing import Awaitable, Callable, List
 
-from golem.managers.base import DoWorkCallable, Work, WorkManager, WorkResult
-from golem.managers.work.mixins import WorkManagerPluginsMixin
+from golem.managers.base import Work, WorkManager, WorkResult
+from golem.managers.work.mixins import WorkManagerDoWorkMixin, WorkManagerPluginsMixin
 from golem.node import GolemNode
+from golem.resources import Activity
 from golem.utils.logging import trace_span
 
 logger = logging.getLogger(__name__)
 
 
-class SequentialWorkManager(WorkManagerPluginsMixin, WorkManager):
-    def __init__(self, golem: GolemNode, do_work: DoWorkCallable, *args, **kwargs):
-        self._do_work = do_work
+class SequentialWorkManager(WorkManagerPluginsMixin, WorkManagerDoWorkMixin, WorkManager):
+    def __init__(
+        self, golem: GolemNode, get_activity: Callable[[], Awaitable[Activity]], *args, **kwargs
+    ):
+        self._get_activity = get_activity
 
         super().__init__(*args, **kwargs)
 

--- a/golem/resources/agreement/agreement.py
+++ b/golem/resources/agreement/agreement.py
@@ -87,13 +87,12 @@ class Agreement(Resource[RequestorApi, models.Agreement, "Proposal", Activity, _
         """
         try:
             await self.api.terminate_agreement(self.id, request_body={"message": reason})
+            await self.node.event_bus.emit(AgreementClosed(self))
         except ApiException as e:
             if self._is_permanent_410(e):
                 pass
             else:
                 raise
-
-        await self.node.event_bus.emit(AgreementClosed(self))
 
     @property
     def invoice(self) -> Optional[Invoice]:


### PR DESCRIPTION
 - ActivityManager now has `get_activity` method
 - `do_work` was moved to WorkManager
 - DefaultAgreementManager now ensure closure of all agreements created by itself on `stop`
 - Added `ActivityWrapperMixin` which allows activity managers to control activities created by itself (managed object)
 - Fixed when `AgreementClosed` is emitted by resource