### PR TITLE
strict exceeding checking (motivation max price = 0)

### DIFF
--- a/golem/managers/proposal/plugins/reject_costs_exceeds.py
+++ b/golem/managers/proposal/plugins/reject_costs_exceeds.py
@@ -38,7 +38,7 @@ class RejectIfCostsExceeds(ProposalManagerPlugin):
 
                 continue
 
-            if cost is not None and self._cost <= cost:
+            if cost is not None and self._cost < cost:
                 if not proposal.initial:
                     await proposal.reject(
                         f"Exceeds costs `{self._pricing_callable}` limit of `{self._cost}`!"


### PR DESCRIPTION
When a user wants to set `max_start_price` to `0` they mean that providers with 0 GLM start price should get accepted.
This is not what happens right now (this can be demonstrated with `ray-on-golem network-stats`)

I am not sure if the one line I found is the only one required :)