### PR TITLE
Error propagation

### DIFF
--- a/golem/event_bus/in_memory/event_bus.py
+++ b/golem/event_bus/in_memory/event_bus.py
@@ -30,9 +30,7 @@ class InMemoryEventBus(EventBus[_CallbackHandler]):
     @trace_span()
     async def start(self):
         if self.is_started():
-            message = "Event bus is already started!"
-            logger.debug(f"Starting event bus failed with `{message}`")
-            raise EventBusError(message)
+            raise EventBusError("Event bus is already started!")
 
         self._process_event_queue_loop_task = create_task_with_logging(
             self._process_event_queue_loop(),
@@ -41,11 +39,6 @@ class InMemoryEventBus(EventBus[_CallbackHandler]):
 
     @trace_span()
     async def stop(self):
-        if not self.is_started():
-            message = "Event bus is not started!"
-            logger.debug(f"Stopping event bus failed with `{message}`")
-            raise EventBusError(message)
-
         await self._event_queue.join()
 
         if self._process_event_queue_loop_task is not None:

--- a/golem/managers/demand/refreshing.py
+++ b/golem/managers/demand/refreshing.py
@@ -61,9 +61,9 @@ class RefreshingDemandManager(BackgroundLoopMixin, DemandManager):
                 await self._create_and_subscribe_demand()
         except Exception as e:
             self._initial_proposals.set_exception(e)
-            logger.exception(
+            logger.debug(
                 "Encountered unexpected exception while handling demands,"
-                " background loop will be stopped!"
+                " exception is set and background loop will be stopped!"
             )
         finally:
             await self._stop_consuming_initial_proposals()

--- a/golem/managers/demand/refreshing.py
+++ b/golem/managers/demand/refreshing.py
@@ -10,7 +10,7 @@ from golem.payload import Payload
 from golem.payload import defaults as payload_defaults
 from golem.resources import Allocation, Demand, Proposal
 from golem.resources.demand.demand_builder import DemandBuilder
-from golem.utils.asyncio import ErrorReportingQueue, create_task_with_logging
+from golem.utils.asyncio import ErrorReportingQueue, create_task_with_logging, ensure_cancelled_many
 from golem.utils.logging import get_trace_id_name, trace_span
 
 logger = logging.getLogger(__name__)
@@ -54,19 +54,22 @@ class RefreshingDemandManager(BackgroundLoopMixin, DemandManager):
     async def _background_loop(self) -> None:
         try:
             while True:
-                await self._wait_for_demand_to_expire()
-                self._stop_consuming_initial_proposals()
+                if self._demands:
+                    await self._wait_for_demand_to_expire()
+                    await self._stop_consuming_initial_proposals()
+
                 await self._create_and_subscribe_demand()
         except Exception as e:
             self._initial_proposals.set_exception(e)
+            logger.exception(
+                "Encountered unexpected exception while handling demands,"
+                " background loop will be stopped!"
+            )
         finally:
-            self._stop_consuming_initial_proposals()
+            await self._stop_consuming_initial_proposals()
             await self._unsubscribe_demands()
 
     async def _wait_for_demand_to_expire(self):
-        if not self._demands:
-            return
-
         await self._demands[-1][0].get_data()
         expiration_date = self._demands[-1][0].get_expiration_date()
         remaining = expiration_date - datetime.now(timezone.utc)
@@ -107,8 +110,8 @@ class RefreshingDemandManager(BackgroundLoopMixin, DemandManager):
             pass
 
     @trace_span()
-    def _stop_consuming_initial_proposals(self) -> List[bool]:
-        return [d[1].cancel() for d in self._demands]
+    async def _stop_consuming_initial_proposals(self) -> None:
+        await ensure_cancelled_many([d[1] for d in self._demands])
 
     @trace_span()
     async def _prepare_demand_builder(self, allocation: Allocation) -> DemandBuilder:

--- a/golem/managers/mixins.py
+++ b/golem/managers/mixins.py
@@ -25,9 +25,6 @@ class BackgroundLoopMixin:
         )
 
     async def stop(self) -> None:
-        if not self.is_started():
-            raise ManagerException("Already stopped!")
-
         if self._background_loop_task is not None:
             await ensure_cancelled(self._background_loop_task)
             self._background_loop_task = None

--- a/golem/managers/payment/pay_all.py
+++ b/golem/managers/payment/pay_all.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 
 from ya_payment import ApiException
 
-from golem.managers.base import PaymentManager, ManagerException
+from golem.managers.base import ManagerException, PaymentManager
 from golem.node import GolemNode
 from golem.payload.defaults import DEFAULT_PAYMENT_DRIVER, DEFAULT_PAYMENT_NETWORK
 from golem.resources import (

--- a/golem/managers/proposal/plugins/negotiating/negotiating_plugin.py
+++ b/golem/managers/proposal/plugins/negotiating/negotiating_plugin.py
@@ -7,7 +7,7 @@ from typing import Optional, Sequence
 from ya_market import ApiException
 
 from golem.managers import ProposalManagerPlugin, RejectProposal
-from golem.managers.base import ProposalNegotiator, ManagerPluginException
+from golem.managers.base import ManagerPluginException, ProposalNegotiator
 from golem.resources import DemandData, Proposal
 from golem.utils.asyncio.tasks import resolve_maybe_awaitable
 from golem.utils.logging import trace_span

--- a/golem/managers/proposal/plugins/negotiating/negotiating_plugin.py
+++ b/golem/managers/proposal/plugins/negotiating/negotiating_plugin.py
@@ -7,7 +7,7 @@ from typing import Optional, Sequence
 from ya_market import ApiException
 
 from golem.managers import ProposalManagerPlugin, RejectProposal
-from golem.managers.base import ProposalNegotiator
+from golem.managers.base import ProposalNegotiator, ManagerPluginException
 from golem.resources import DemandData, Proposal
 from golem.utils.asyncio.tasks import resolve_maybe_awaitable
 from golem.utils.logging import trace_span
@@ -92,7 +92,7 @@ class NegotiatingPlugin(ProposalManagerPlugin):
                 timeout=self._proposal_response_timeout,
             )
         except (StopAsyncIteration, asyncio.TimeoutError) as e:
-            raise RuntimeError("Failed to receive proposal response!") from e
+            raise ManagerPluginException("Failed to receive proposal response!") from e
 
     @trace_span()
     async def _send_demand_proposal(
@@ -104,7 +104,7 @@ class NegotiatingPlugin(ProposalManagerPlugin):
                 demand_data.constraints,
             )
         except (ApiException, asyncio.TimeoutError) as e:
-            raise RuntimeError(f"Failed to send proposal response! {e}") from e
+            raise ManagerPluginException(f"Failed to send proposal response! {e}") from e
 
     @trace_span()
     async def _reject_proposal(self, offer_proposal: Proposal) -> None:

--- a/golem/managers/proposal/plugins/scoring/scoring_buffer.py
+++ b/golem/managers/proposal/plugins/scoring/scoring_buffer.py
@@ -92,9 +92,9 @@ class ProposalScoringBuffer(ProposalScoringMixin, ProposalBuffer):
                 proposals = await self._buffer.get_requested(self._scoring_debounce)
             except Exception as e:
                 await self._buffer_scored.set_exception(e)
-                logger.error(
+                logger.debug(
                     "Encountered unexpected exception while getting proposal,"
-                    " background loop will be stopped!"
+                    " exception is set and background loop will be stopped!"
                 )
 
                 return

--- a/golem/managers/proposal/plugins/scoring/scoring_buffer.py
+++ b/golem/managers/proposal/plugins/scoring/scoring_buffer.py
@@ -87,7 +87,18 @@ class ProposalScoringBuffer(ProposalScoringMixin, ProposalBuffer):
                 "Waiting for any proposals to score with debounce of `%s`...",
                 self._scoring_debounce,
             )
-            proposals = await self._buffer.get_requested(self._scoring_debounce)
+
+            try:
+                proposals = await self._buffer.get_requested(self._scoring_debounce)
+            except Exception as e:
+                await self._buffer_scored.set_exception(e)
+                logger.error(
+                    "Encountered unexpected exception while getting proposal,"
+                    " background loop will be stopped!"
+                )
+
+                return
+
             logger.debug(
                 "Waiting for any proposals done, %d new proposals will be scored", len(proposals)
             )

--- a/golem/utils/asyncio/buffer.py
+++ b/golem/utils/asyncio/buffer.py
@@ -374,9 +374,9 @@ class BackgroundFillBuffer(ComposableBuffer[TItem]):
                     item = await self._fill_func()
                 except Exception as e:
                     await self.set_exception(e)
-                    logger.error(
+                    logger.debug(
                         "Encountered unexpected exception while adding a new item,"
-                        " worker loops will be stopped!"
+                        " exception is set and worker loops will be stopped!"
                     )
 
                     loop = asyncio.get_event_loop()

--- a/tests/unit/test_event_bus.py
+++ b/tests/unit/test_event_bus.py
@@ -48,8 +48,9 @@ async def test_start_stop():
 
     assert not event_bus.is_started()
 
-    with pytest.raises(EventBusError, match="not started"):
-        await event_bus.stop()
+    await event_bus.stop()
+
+    assert not event_bus.is_started()
 
 
 async def test_on_off(mocker):


### PR DESCRIPTION
What I've done:
* Made that errors are now forwarded through the chain of managers to be raised in the activity creation step ultimately - a first explicit example is a failure in `get_allocation`.
* Made `.stop()` methods to be able to be called multiple times, as from now we have a case for stopping the manager when its background loop was already stopped due to a previously propagated error.
* Optimized time needed to raise a propagated error in the buffers, by making `Buffer.wait_for_any_items()` raise errors set by `set_exception`, so `get_requested()` will raise the given error instantly and will not wait to its debounce time.
* Made a few tweaks for RefreshingDemandManager loop.
* Updated the test cases

Notable remarks:
* To test `get_allocation` failures, just give `total_budget` in yaml a big number like 1000+