### PR TITLE
Async get_expiration_date in Demand and Proposal resources

### DIFF
--- a/golem/managers/demand/refreshing.py
+++ b/golem/managers/demand/refreshing.py
@@ -71,7 +71,7 @@ class RefreshingDemandManager(BackgroundLoopMixin, DemandManager):
 
     async def _wait_for_demand_to_expire(self):
         await self._demands[-1][0].get_data()
-        expiration_date = self._demands[-1][0].get_expiration_date()
+        expiration_date = await self._demands[-1][0].get_expiration_date()
         remaining = expiration_date - datetime.now(timezone.utc)
         await asyncio.sleep(remaining.total_seconds())
 

--- a/golem/resources/demand/demand.py
+++ b/golem/resources/demand/demand.py
@@ -142,7 +142,8 @@ class Demand(Resource[RequestorApi, models.Demand, _NULL, Proposal, _NULL], Yagn
 
         return self._demand_data
 
-    def get_expiration_date(self) -> datetime:
+    async def get_expiration_date(self) -> datetime:
         """Return expiration date to auto unsubscribe."""
+        await self.get_data()
 
         return cast(datetime, self.data.timestamp) + DEFAULT_TTL

--- a/golem/resources/proposal/proposal.py
+++ b/golem/resources/proposal/proposal.py
@@ -233,13 +233,15 @@ class Proposal(
             self._provider_node_name = node_info.name
         return self._provider_node_name
 
-    def get_expiration_date(self) -> datetime:
+    async def get_expiration_date(self) -> datetime:
         """Return expiration date to auto unsubscribe.
 
         Note: As Proposal can have different expiration date than its Demand, it would be unusable
         after demand expiration anyway, hence earliest from both dates is returned.
         """
-        demand_expiration_date = self.demand.get_expiration_date()
+        await self.get_data()
+
+        demand_expiration_date = await self.demand.get_expiration_date()
         proposal_expiration_date = cast(datetime, self.data.timestamp) + DEFAULT_TTL
 
         return min(proposal_expiration_date, demand_expiration_date)


### PR DESCRIPTION
What I've done:

* Made async `get_expiration_date` in Demand and Proposal to be more consistent with recently added code.
