### PR TITLE
Fix debit note frequency validation

### DIFF
--- a/golem/resources/base.py
+++ b/golem/resources/base.py
@@ -1,6 +1,8 @@
 import asyncio
+import logging
 import re
 from abc import ABC, ABCMeta
+from datetime import datetime, timezone
 from functools import wraps
 from typing import (
     TYPE_CHECKING,
@@ -28,6 +30,8 @@ from golem.utils.low import TRequestorApi, get_requestor_api
 
 if TYPE_CHECKING:
     from golem.node import GolemNode
+
+logger = logging.getLogger(__name__)
 
 all_api_exceptions = (
     PaymentApiException,
@@ -126,6 +130,7 @@ class Resource(
     """
 
     def __init__(self, node: "GolemNode", id_: str, data: Optional[TModel] = None):
+        self._created_at = datetime.now(timezone.utc)
         self._node = node
         self._id = id_
         self._data: Optional[TModel] = data
@@ -245,6 +250,10 @@ class Resource(
     def node(self) -> "GolemNode":
         """:any:`GolemNode` that defines the context of this :class:`Resource`."""
         return self._node
+
+    @property
+    def created_at(self) -> datetime:
+        return self._created_at
 
     ####################
     #   DATA LOADING

--- a/golem/resources/debit_note/debit_note.py
+++ b/golem/resources/debit_note/debit_note.py
@@ -91,7 +91,7 @@ class DebitNote(Resource[RequestorApi, models.DebitNote, "Activity", _NULL, _NUL
         received_payment_timeout = payment_due_date - debit_note_created_at
         if received_payment_timeout + payment_timeout_grace_period < payment_timeout_timedelta:
             raise PaymentValidationException(
-                f"Payment timeout is shorter then agreed {payment_due_date=}"
+                f"Payment timeout is shorter than agreed {payment_due_date=}"
                 f"{received_payment_timeout=} < {payment_timeout_timedelta=}."
             )
 
@@ -122,7 +122,7 @@ class DebitNote(Resource[RequestorApi, models.DebitNote, "Activity", _NULL, _NUL
         ):
             raise PaymentValidationException(
                 f"Too many debit notes received {time_since_last_debit_note=}"
-                f"{debit_note_interval_timedelta=}"
+                f" {debit_note_interval_timedelta=}"
             )
 
     def validate_payment_data(

--- a/golem/resources/debit_note/debit_note.py
+++ b/golem/resources/debit_note/debit_note.py
@@ -90,7 +90,7 @@ class DebitNote(Resource[RequestorApi, models.DebitNote, "Activity", _NULL, _NUL
             raise PaymentValidationException(
                 f"Too many debit notes received {previous_payable_debit_notes_count=}. "
                 f"{agreement_duration + grace_period}"
-                f" < {previous_payable_debit_notes_count  * interval}"
+                f" < {previous_payable_debit_notes_count * interval}"
             )
 
     @classmethod

--- a/golem/resources/utils/payment.py
+++ b/golem/resources/utils/payment.py
@@ -166,6 +166,7 @@ def validate_payment_calculated_cost(
     coeffs: LinearCoeffs,
     amount: Decimal,
     usage_counter_vector: List,
+    grace_amount: Decimal = 100 * ETH_EXPONENT,
 ) -> Decimal:
     """Validate payment amount calculated from vector usage.
 
@@ -178,7 +179,7 @@ def validate_payment_calculated_cost(
         calculated_cost += price * Decimal(value)
     calculated_cost = eth_decimal(calculated_cost)
 
-    if amount > calculated_cost:
+    if amount > calculated_cost + grace_amount:
         raise PaymentValidationException(
             "Total amount due exceeds expected calculated cost " f"{amount} > {calculated_cost}"
         )


### PR DESCRIPTION
Changes:
- Added `created_at` property to all resources. FYI existing `ResourceMeta` class ensures all resources are singletons and can only be created once and after that are kept in the memory.
- Fixed `validate_mid_agreement_payment` using wrong property
- Adjusted `validate_mid_agreement_payment` so it checks agains last pay document (instead of using avareage from all documents related to the agreement)
- Adjusted debit note validation so it is using `Activity.created_at` instead of agreement duration when applicable 
- Adjusted debit note and invoice validation so it is using `created_at` instead of `timestamp` when applicable 
- Added `grace_amount` to amount calculated using usage vector
- Adjusted and extended unit tests to above changes