### PR TITLE
Stability fixes

### DIFF
--- a/golem/managers/demand/aggregating.py
+++ b/golem/managers/demand/aggregating.py
@@ -5,7 +5,12 @@ from typing import Awaitable, Callable, MutableMapping, Sequence
 from golem.managers import DemandManager
 from golem.node import GolemNode
 from golem.resources import Proposal
-from golem.utils.asyncio import create_task_with_logging, ensure_cancelled_many
+from golem.utils.asyncio import (
+    Buffer,
+    SimpleBuffer,
+    create_task_with_logging,
+    ensure_cancelled_many,
+)
 from golem.utils.logging import trace_span
 
 
@@ -24,7 +29,7 @@ class AggregatingDemandManager(DemandManager):
 
         self._task_map: MutableMapping[Callable[[], Awaitable[Proposal]], asyncio.Task] = {}
 
-        self._queue: asyncio.Queue[Proposal] = asyncio.Queue()
+        self._buffer: Buffer[Proposal] = SimpleBuffer()
 
     @trace_span("Stopping AggregatingDemandManager", log_level=logging.INFO)
     async def stop(self) -> None:
@@ -41,21 +46,27 @@ class AggregatingDemandManager(DemandManager):
         are saved, they will be returned in completion  order.
         """
 
-        try:
-            return self._queue.get_nowait()
-        except asyncio.QueueEmpty:
-            pass
+        if self._buffer.size():
+            return await self._buffer.get()
 
         async with self._lock:
             for func in self._get_initial_proposal_funcs:
                 if func not in self._task_map:
                     self._task_map[func] = create_task_with_logging(self._feed_queue(func))
 
-        return await self._queue.get()
+        return await self._buffer.get()
 
     async def _feed_queue(self, func: Callable[[], Awaitable[Proposal]]):
-        proposal = await func()
-        self._queue.put_nowait(proposal)
+        try:
+            proposal = await func()
+        except asyncio.CancelledError:
+            # we don't want to store cancellation error
+            raise
+        except Exception as e:
+            await self._buffer.set_exception(e)
+        else:
+            self._buffer.reset_exception()
+            await self._buffer.put(proposal)
 
         async with self._lock:
             del self._task_map[func]

--- a/golem/managers/payment/default.py
+++ b/golem/managers/payment/default.py
@@ -41,6 +41,7 @@ class DefaultPaymentManager(PaymentManager):
         self._network = network
         self._driver = driver
         self._shutdown_timeout = shutdown_timeout.total_seconds()
+        self._lock = asyncio.Lock()
 
         self._allocation: Optional[Allocation] = None
 
@@ -62,10 +63,15 @@ class DefaultPaymentManager(PaymentManager):
 
     @trace_span("Getting allocation", show_results=True, log_level=logging.INFO)
     async def get_allocation(self) -> Allocation:
-        if self._allocation is None:
-            self._allocation = await self._create_allocation()
+        async with self._lock:
+            if self._allocation is None:
+                self._allocation = await self._create_allocation(
+                    Decimal(self._budget),
+                    self._network,
+                    self._driver,
+                )
 
-        return self._allocation
+            return self._allocation
 
     async def _release_allocation(self) -> None:
         if self._allocation is None:
@@ -74,11 +80,11 @@ class DefaultPaymentManager(PaymentManager):
         await self._allocation.release()
         self._allocation = None
 
-    @trace_span()
-    async def _create_allocation(self) -> Allocation:
+    @trace_span(show_arguments=True, show_results=True)
+    async def _create_allocation(self, budget: Decimal, network: str, driver: str) -> Allocation:
         try:
             return await Allocation.create_any_account(
-                self._golem, Decimal(self._budget), self._network, self._driver
+                self._golem, budget, network, driver
             )
         except ApiException as e:
             raise ManagerException(json.loads(e.body)["message"]) from e

--- a/golem/managers/payment/default.py
+++ b/golem/managers/payment/default.py
@@ -71,7 +71,7 @@ class DefaultPaymentManager(PaymentManager):
                     self._driver,
                 )
 
-        return self._allocation
+        return self._allocation  # type: ignore[return-value]
 
     async def _release_allocation(self) -> None:
         if self._allocation is None:

--- a/golem/managers/payment/default.py
+++ b/golem/managers/payment/default.py
@@ -64,14 +64,14 @@ class DefaultPaymentManager(PaymentManager):
     @trace_span("Getting allocation", show_results=True, log_level=logging.INFO)
     async def get_allocation(self) -> Allocation:
         async with self._lock:
-            if self._allocation is None:
+            if not self._allocation:
                 self._allocation = await self._create_allocation(
                     Decimal(self._budget),
                     self._network,
                     self._driver,
                 )
 
-            return self._allocation
+        return self._allocation
 
     async def _release_allocation(self) -> None:
         if self._allocation is None:

--- a/golem/managers/payment/default.py
+++ b/golem/managers/payment/default.py
@@ -83,9 +83,7 @@ class DefaultPaymentManager(PaymentManager):
     @trace_span(show_arguments=True, show_results=True)
     async def _create_allocation(self, budget: Decimal, network: str, driver: str) -> Allocation:
         try:
-            return await Allocation.create_any_account(
-                self._golem, budget, network, driver
-            )
+            return await Allocation.create_any_account(self._golem, budget, network, driver)
         except ApiException as e:
             raise ManagerException(json.loads(e.body)["message"]) from e
 

--- a/golem/managers/proposal/plugins/buffer.py
+++ b/golem/managers/proposal/plugins/buffer.py
@@ -80,7 +80,7 @@ class ProposalBuffer(ProposalManagerPlugin):
                 message,
             ):
                 logger.warning(
-                    "Proposal assumed already expired. Consider shortening the expiry duration."
+                    f"Proposal assumed already expired. Consider shortening the expiry duration: `{message}`"
                 )
             else:
                 raise

--- a/golem/managers/proposal/plugins/buffer.py
+++ b/golem/managers/proposal/plugins/buffer.py
@@ -80,7 +80,8 @@ class ProposalBuffer(ProposalManagerPlugin):
                 message,
             ):
                 logger.warning(
-                    f"Proposal assumed already expired. Consider shortening the expiry duration: `{message}`"
+                    f"Proposal assumed already expired. Consider shortening the expiry duration:"
+                    f" `{message}`"
                 )
             else:
                 raise

--- a/golem/managers/proposal/plugins/buffer.py
+++ b/golem/managers/proposal/plugins/buffer.py
@@ -71,11 +71,13 @@ class ProposalBuffer(ProposalManagerPlugin):
         logger.debug("Rejecting expired `%r` and requesting fill", proposal)
 
         try:
-            await proposal.reject("Proposal no longer needed due to its near expiration.")
+            if proposal.draft:
+                await proposal.reject("Proposal no longer needed due to its near expiration.")
         except ApiException as e:
             message = json.loads(e.body)["message"]
             if e.status == 400 and re.match(
-                r"^Subscription \[([^]]+)\] (wasn't found|expired).$", message
+                r"^Subscription \[([^]]+)\] (wasn't found|expired|was already unsubscribed).$",
+                message,
             ):
                 logger.warning(
                     "Proposal assumed already expired. Consider shortening the expiry duration."

--- a/golem/managers/proposal/plugins/negotiating/negotiating_plugin.py
+++ b/golem/managers/proposal/plugins/negotiating/negotiating_plugin.py
@@ -48,21 +48,24 @@ class NegotiatingPlugin(ProposalManagerPlugin):
             except ProposalRejected as e:
                 self._fail_count += 1
                 logger.debug(
-                    f"Negotiation based on proposal `{proposal}` from `{provider_name}` failed as it was rejected by the provider: `{e}`, retrying with new one..."
+                    f"Negotiation based on proposal `{proposal}` from `{provider_name}` failed as"
+                    f" it was rejected by the provider: `{e}`, retrying with new one..."
                     "\nsuccess count: "
                     f"{self._success_count}/{self._success_count + self._fail_count}",
                 )
             except RejectProposal as e:
                 self._fail_count += 1
                 logger.debug(
-                    f"Negotiation based on proposal `{proposal}` from `{provider_name}` failed as it was rejected by requestor: `{e}`, retrying with new one..."
+                    f"Negotiation based on proposal `{proposal}` from `{provider_name}` failed as"
+                    f" it was rejected by requestor: `{e}`, retrying with new one..."
                     "\nsuccess count: "
                     f"{self._success_count}/{self._success_count + self._fail_count}",
                 )
             except Exception:
                 self._fail_count += 1
                 logger.debug(
-                    f"Negotiation based on proposal `{proposal}` from `{provider_name}` failed, retrying with new one..."
+                    f"Negotiation based on proposal `{proposal}` from `{provider_name}` failed,"
+                    f" retrying with new one..."
                     "\nsuccess count: "
                     f"{self._success_count}/{self._success_count + self._fail_count}",
                     exc_info=True,

--- a/golem/managers/proposal/plugins/negotiating/negotiating_plugin.py
+++ b/golem/managers/proposal/plugins/negotiating/negotiating_plugin.py
@@ -55,8 +55,8 @@ class NegotiatingPlugin(ProposalManagerPlugin):
                     reason = ""
 
                 logger.debug(
-                    f"Negotiation based on proposal `{proposal}` from `{provider_name}` failed{reason},"
-                    f" retrying with new one..."
+                    f"Negotiation based on proposal `{proposal}` from `{provider_name}`"
+                    f" failed{reason}, retrying with new one..."
                     "\nsuccess count: "
                     f"{self._success_count}/{self._success_count + self._fail_count}",
                     exc_info=not isinstance(e, (ProposalRejected, RejectProposal)),

--- a/golem/managers/proposal/plugins/negotiating/negotiating_plugin.py
+++ b/golem/managers/proposal/plugins/negotiating/negotiating_plugin.py
@@ -9,6 +9,7 @@ from ya_market import ApiException
 from golem.managers import ProposalManagerPlugin, RejectProposal
 from golem.managers.base import ManagerPluginException, ProposalNegotiator
 from golem.resources import DemandData, Proposal
+from golem.resources.proposal.exceptions import ProposalRejected
 from golem.utils.asyncio.tasks import resolve_maybe_awaitable
 from golem.utils.logging import trace_span
 
@@ -91,6 +92,8 @@ class NegotiatingPlugin(ProposalManagerPlugin):
                 demand_proposal.responses().__anext__(),
                 timeout=self._proposal_response_timeout,
             )
+        except ProposalRejected as e:
+            if
         except (StopAsyncIteration, asyncio.TimeoutError) as e:
             raise ManagerPluginException("Failed to receive proposal response!") from e
 

--- a/golem/managers/proposal/plugins/scoring/scoring_buffer.py
+++ b/golem/managers/proposal/plugins/scoring/scoring_buffer.py
@@ -1,5 +1,3 @@
-import json
-
 import asyncio
 import logging
 from datetime import timedelta

--- a/golem/managers/proposal/plugins/scoring/scoring_buffer.py
+++ b/golem/managers/proposal/plugins/scoring/scoring_buffer.py
@@ -108,7 +108,6 @@ class ProposalScoringBuffer(ProposalScoringMixin, ProposalBuffer):
             logger.debug("Scoring total %d proposals...", len(proposals))
 
             scored_proposals = await self.do_scoring(proposals)
-
             await self._buffer_scored.put_all([proposal for _, proposal in scored_proposals])
 
             logger.debug("Scoring total %d proposals done", len(proposals))

--- a/golem/managers/proposal/plugins/scoring/scoring_buffer.py
+++ b/golem/managers/proposal/plugins/scoring/scoring_buffer.py
@@ -1,3 +1,5 @@
+import json
+
 import asyncio
 import logging
 from datetime import timedelta
@@ -108,6 +110,10 @@ class ProposalScoringBuffer(ProposalScoringMixin, ProposalBuffer):
             logger.debug("Scoring total %d proposals...", len(proposals))
 
             scored_proposals = await self.do_scoring(proposals)
+
+            with open('./scored.json', 'a') as file:
+                file.writelines([f"{sp[0]} {await sp[1].get_provider_name()}\n" for sp in scored_proposals])
+
             await self._buffer_scored.put_all([proposal for _, proposal in scored_proposals])
 
             logger.debug("Scoring total %d proposals done", len(proposals))

--- a/golem/managers/proposal/plugins/scoring/scoring_buffer.py
+++ b/golem/managers/proposal/plugins/scoring/scoring_buffer.py
@@ -111,9 +111,6 @@ class ProposalScoringBuffer(ProposalScoringMixin, ProposalBuffer):
 
             scored_proposals = await self.do_scoring(proposals)
 
-            with open('./scored.json', 'a') as file:
-                file.writelines([f"{sp[0]} {await sp[1].get_provider_name()}\n" for sp in scored_proposals])
-
             await self._buffer_scored.put_all([proposal for _, proposal in scored_proposals])
 
             logger.debug("Scoring total %d proposals done", len(proposals))

--- a/golem/utils/asyncio/buffer.py
+++ b/golem/utils/asyncio/buffer.py
@@ -5,7 +5,6 @@ from abc import ABC, abstractmethod
 from collections import defaultdict
 from contextlib import asynccontextmanager
 from datetime import timedelta
-from functools import partial
 from typing import (
     Awaitable,
     Callable,
@@ -244,7 +243,7 @@ class ExpirableBuffer(ComposableBuffer[TItem]):
         self._expiration_tasks[id(item)].append(
             create_delayed_task_with_logging(
                 expiration,
-                partial(self._expire_item_shielded, item),
+                self._expire_item_shielded(item),
                 trace_id=get_trace_id_name(self, f"item-expire-{item}"),
             )
         )

--- a/golem/utils/asyncio/tasks.py
+++ b/golem/utils/asyncio/tasks.py
@@ -2,7 +2,8 @@ import asyncio
 import contextvars
 import inspect
 import logging
-from typing import Iterable, Optional, TypeVar, cast
+from datetime import timedelta
+from typing import Awaitable, Callable, Coroutine, Iterable, Optional, Tuple, TypeVar, cast
 
 from golem.utils.logging import trace_id_var
 from golem.utils.typing import MaybeAwaitable
@@ -12,7 +13,35 @@ T = TypeVar("T")
 logger = logging.getLogger(__name__)
 
 
-def create_task_with_logging(coro, *, trace_id: Optional[str] = None) -> asyncio.Task:
+def create_task_with_logging(coro: Coroutine, *, trace_id: Optional[str] = None) -> asyncio.Task:
+    task, task_name = _create_task_with_context(coro, trace_id=trace_id)
+
+    logger.debug("Task `%s` created", task_name)
+
+    return task
+
+
+def create_delayed_task_with_logging(
+    delay: timedelta, func: Callable[[], Awaitable], *, trace_id: Optional[str] = None
+) -> asyncio.Task:
+    task, task_name = _create_task_with_context(
+        _create_delayed_task_with_logging(delay, func), trace_id=trace_id
+    )
+
+    logger.debug("Task `%s` created with delay `%s`", task_name, delay)
+
+    return task
+
+
+async def _create_delayed_task_with_logging(delay: timedelta, func: Callable[[], Awaitable]):
+    await asyncio.sleep(delay.total_seconds())
+
+    return await func()
+
+
+def _create_task_with_context(
+    coro: Coroutine, *, trace_id: Optional[str] = None
+) -> Tuple[asyncio.Task, str]:
     context = contextvars.copy_context()
     task = context.run(_create_task_with_logging, coro, trace_id=trace_id)
 
@@ -21,12 +50,10 @@ def create_task_with_logging(coro, *, trace_id: Optional[str] = None) -> asyncio
     else:
         task_name = task.get_name()
 
-    logger.debug("Task `%s` created", task_name)
-
-    return task
+    return task, task_name
 
 
-def _create_task_with_logging(coro, *, trace_id: Optional[str] = None) -> asyncio.Task:
+def _create_task_with_logging(coro: Coroutine, *, trace_id: Optional[str] = None) -> asyncio.Task:
     if trace_id is not None:
         trace_id_var.set(trace_id)
 


### PR DESCRIPTION
What I've done:
- Made AggregatingDemandManager aware of the exceptions that can happen in underlying `get_initial_proposal_funcs`, aka exception bubbling
- Added lock in DefaultPaymentManager allocation creation, no more multiple allocations at once!
- Made more verbose exception logs in NegotiatingPlugin
- Made more robust expirations in ProposalBuffer
- Made more robust task canceling in ExpirableBuffer

Notable remarks:
- Spawning tons of tasks for nearly exact expiration is not optimal, but reworking it on a single task that wakes up on the earliest expiration is rather tricky due to
  1. Lack of direct access to all items in the buffer without rebuilding the collection with `get_all` and `put_all`.
  2. Usage of relative expiration time instead of absolute time
  3. Duplicating data to avoid scanning the whole collection for the earliest item to expire