### PR TITLE
Debit note and invoice validation fixes

### DIFF
--- a/golem/resources/invoice/invoice.py
+++ b/golem/resources/invoice/invoice.py
@@ -44,8 +44,8 @@ class Invoice(Resource[RequestorApi, models.Invoice, "Agreement", _NULL, _NULL])
         self, total_amount: Decimal
     ) -> Tuple[Optional[timedelta], Decimal]:
         """Get cumulative time and amount since last debit notes from all activities."""
-        cumulative_time_from_all_activities: Optional[timedelta] = timedelta()
-        cumulative_amount_from_all_activities: Decimal = Decimal(0)
+        cumulative_time_from_all_activities = timedelta()
+        cumulative_amount_from_all_activities = Decimal(0)
 
         for activity in self.agreement.activities:
             # Look for a newest Debit Note that came before the invoice
@@ -61,7 +61,7 @@ class Invoice(Resource[RequestorApi, models.Invoice, "Agreement", _NULL, _NULL])
                 break
 
         if cumulative_time_from_all_activities == timedelta():
-            cumulative_time_from_all_activities = None
+            cumulative_time_from_all_activities = None  # type: ignore[assignment]
 
         return (
             cumulative_time_from_all_activities,

--- a/golem/resources/invoice/invoice.py
+++ b/golem/resources/invoice/invoice.py
@@ -42,10 +42,10 @@ class Invoice(Resource[RequestorApi, models.Invoice, "Agreement", _NULL, _NULL])
 
     async def get_time_and_amount_since_latest_debit_notes(
         self, total_amount: Decimal
-    ) -> Tuple[timedelta, Decimal]:
+    ) -> Tuple[Optional[timedelta], Decimal]:
         """Get cumulative time and amount since last debit notes from all activities."""
-        cumulative_time_from_all_activities = timedelta()
-        cumulative_amount_from_all_activities = Decimal(0)
+        cumulative_time_from_all_activities: Optional[timedelta] = timedelta()
+        cumulative_amount_from_all_activities: Decimal = Decimal(0)
 
         for activity in self.agreement.activities:
             # Look for a newest Debit Note that came before the invoice
@@ -59,6 +59,9 @@ class Invoice(Resource[RequestorApi, models.Invoice, "Agreement", _NULL, _NULL])
                         debit_note.data.total_amount_due
                     )
                 break
+
+        if cumulative_time_from_all_activities == timedelta():
+            cumulative_time_from_all_activities = None
 
         return (
             cumulative_time_from_all_activities,


### PR DESCRIPTION
Fixes:
- ~~Invoices received from agreements with 0 debit notes were always rejected~~
- ~~Last debit note was sometimes rejected~~

Other changes:
- Brought back previous logic which validated if debit notes are sent to often 